### PR TITLE
fix: moved jest to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,19 +17,19 @@
     "prepublish": "yarn run build"
   },
   "dependencies": {
-    "@types/jest": "^29.5.3",
     "axios": "^1.4.0",
-    "jest": "^29.6.2",
     "remeda": "^1.24.0",
-    "ts-jest": "^29.1.1",
     "ts-node": "^10.9.1"
   },
   "devDependencies": {
     "@playwright-testing-library/test": "^4.0.1",
     "@playwright/test": "1.28.1",
+    "@types/jest": "^29.5.3",
     "concurrently": "^8.2.1",
     "http-server": "^14.1.1",
+    "jest": "^29.6.2",
     "rimraf": "^5.0.1",
+    "ts-jest": "^29.1.1",
     "typescript": "^4.8.4"
   }
 }


### PR DESCRIPTION
Currently jest is imported in every project as a hard dependency. It would be better to move this to dev dependencies

(not tested and not verified, but i think jest is not used in your production code)