### PR TITLE
feat!: Store 4xx responses as-is

### DIFF
--- a/src/proxy-server.ts
+++ b/src/proxy-server.ts
@@ -211,6 +211,7 @@ const convertToAxiosRequestConfig = async (
   url: `${port === "443" ? "https" : "http"}://${host}${request.url}`,
   method: request.method,
   data: request.body,
+  validateStatus: (status) => status >= 200 && status < 300 || status >= 400 && status < 500
 });
 
 /** @description Snapshots responses for request and provide them as stubs. */

--- a/use-cases/tests/example-playwright.e2e.spec.ts
+++ b/use-cases/tests/example-playwright.e2e.spec.ts
@@ -73,6 +73,32 @@ test.describe("Mocked API-Error-Responses without spamming your APIs Error loggi
     }
   });
 
+  test.describe("proxy error payload behavior for code", () => {
+    for (const statusCode of [400, 403, 404]) {
+      test(`${statusCode} should not return custom error format`, async ({
+        request,
+      }) => {
+        const response = await request.get(
+          `http://0.0.0.0:8080/status/${statusCode}`
+        );
+        const data = await response.text();
+        expect(JSON.stringify(data)).not.toContain("[HttpApiProxyServer]");
+      });
+    }
+
+    for (const statusCode of [500, 503]) {
+      test(`${statusCode} should return custom error format`, async ({
+        request,
+      }) => {
+        const response = await request.get(
+          `http://0.0.0.0:8080/status/${statusCode}`
+        );
+        const data = await response.json();
+        expect(JSON.stringify(data)).toContain("[HttpApiProxyServer]");
+      });
+    }
+  });
+
   test("forwarding codes are resolved and not teated as errors", async ({
     request,
   }) => {


### PR DESCRIPTION
Previously the proxy server would replace the response body of 4xx responses with its own error structure. This breaks GraphQL APQ[1] which relies on a specific error code to be present in the response body from a 404 response.

This change removes the special treatment of all 4xx errors and caches 4xx responses as-is without modification.

[1] https://www.apollographql.com/docs/apollo-server/performance/apq